### PR TITLE
fixes broken sprite

### DIFF
--- a/code/game/objects/items/oddities.dm
+++ b/code/game/objects/items/oddities.dm
@@ -120,7 +120,7 @@
 /obj/item/weapon/oddity/common/paper_omega
 	name = "collection of obscure reports"
 	desc = "Even the authors seem to be rather skeptical about their findings. The reports are not connected to each other, but their results are similar."
-	icon_state = "paper_omega" //broken icon
+	icon_state = "folder-omega" //changed from "paper_omega"
 	oddity_stats = list(
 		STAT_MEC = 8,
 		STAT_COG = 8,


### PR DESCRIPTION
fixes the broken sprite for the Obscure Reports oddity.
changed from "paper_omega" to "folder-omega"

<!-- Make sure you read the guidelines before conrtibuting! https://wiki.cev-eris.com/Content_GuidelinesEn -->

## About The Pull Request
<!-- Why is it needed, what it fixes. Write up links to closing issues there as well, but make it short. -->
The Obscure Reports oddity had a broken, non-existent icon which made it appear transparent and unclickable.


## Details
<!-- If you need, describe details inside. Remove whole block if not used. -->
<details>
  <summary>Expand</summary>
fixes the Obscure Report's broken sprite
</details>